### PR TITLE
bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-psycopg2==2.8.4
-voluptuous==0.11.1
+psycopg2-binary==2.8.5
+voluptuous==0.11.7


### PR DESCRIPTION
also use psycopg2-binary that does not require build dependencies

Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>